### PR TITLE
Update ContactsList.swift

### DIFF
--- a/SyncEngine/ContactsList.swift
+++ b/SyncEngine/ContactsList.swift
@@ -109,7 +109,7 @@ struct ContactView: View {
 extension Contact {
     
     // In order for the list to update properly when fetch changes from the cloud, we need to use something other than the contact ID for the list item ID.
-    var listID: String { "\(self.id)\(Self.listIDSeparator)\(self.name)" }
+    var listID: String { "\(self.id)\(Self.listIDSeparator)\(self.userModificationDate)" }
     
     static let listIDSeparator = "::"
     


### PR DESCRIPTION
When adding fields to Contact, the original implementation of listID didn't guarantee updates when additional fields were added to Contact unless the new fields were also added here which gets very clunky.

I think a better approach is to make the listID by combining self.id with self.userModificationDate.

This guarantees updates when new fields are added to Contact and I think is a better pattern for developers to implement in their own projects.